### PR TITLE
Tell the RPC api to set the activity to "Listening to.. {band}"

### DIFF
--- a/api/discord/rpc.py
+++ b/api/discord/rpc.py
@@ -49,6 +49,7 @@ class DiscordRPC:
         self.show_username = True
         
         self.show_artist_scrobbles_large = True
+        self.focus_artist = True
         
         # Cache for forced updates
         self.last_fetched_track = None
@@ -272,18 +273,23 @@ class DiscordRPC:
              elif self.use_lastfm_icon:
                  small_image_asset = LASTFM_ICON_URL
                  
+        # Prepare dynamic assets based on Focus Mode
+        display_type = StatusDisplayType.STATE if self.focus_artist else StatusDisplayType.DETAILS
+        
+        rpc_state = track_artist_album if time_remaining_bool and not album_bool else artist
+        
         update_assets = {
             'activity_type': ActivityType.LISTENING,
-            'status_display_type': StatusDisplayType.STATE,
+            'status_display_type': display_type,
             'details': title,
+            'state': rpc_state,
             'buttons': rpc_buttons,
             'small_image': small_image_asset,
             'small_text': rpc_small_image_text,
             'large_text': rpc_large_image_text,
-            # situation-dependent assets
             'large_image': 'artwork' if not time_remaining_bool and not album_bool else artwork,
-            'state': track_artist_album if time_remaining_bool and not album_bool else artist,
-            'end': time_remaining + self.start_time if time_remaining_bool else None}
+            'end': time_remaining + self.start_time if time_remaining_bool else None
+        }
 
         # logging
         state = 'with album' if album_bool else 'without album'

--- a/translations/project.yaml
+++ b/translations/project.yaml
@@ -35,6 +35,9 @@ EN:
   menu_use_default_icon: "Use Default Icon"
   menu_use_lastfm_icon: "Use Last.fm Icon"
   menu_show_username: "Show Username"
+  menu_focus_mode: "Status: Listening to..."
+  menu_focus_artist: "Artist"
+  menu_focus_track: "Track"
 TR:
   pylast_ws_error: "Web servisinde bağlantı sorunu oluştu, bağlantı {} saniye sonra yeniden deneniyor."
   pylast_network_error: "Uygulama Last.fm sunucularıyla iletişim kuramadı, internet bağlantınızı kontrol edin!"
@@ -72,3 +75,6 @@ TR:
   menu_use_default_icon: "Varsayılan İkonu Kullan"
   menu_use_lastfm_icon: "Last.fm İkonunu Kullan"
   menu_show_username: "Kullanıcı Adını Göster"
+  menu_focus_mode: "Durum: Dinliyor..."
+  menu_focus_artist: "Sanatçı"
+  menu_focus_track: "Şarkı"


### PR DESCRIPTION
As title says. Should also be possible to write a menu option to switch the activity status between song title and artist name (though, who would do that? I've seen every other Last.fm Rich Presence app include that option for the sake of customization)

Looks like this:
<img width="146" height="48" alt="image" src="https://github.com/user-attachments/assets/7e1854a8-37a4-4fa3-8d1a-ca6f7332d936" />
