### PR TITLE
feat: Spanish translation

### DIFF
--- a/translations/project.yaml
+++ b/translations/project.yaml
@@ -101,7 +101,7 @@ ES:
   connected_with_time: "Conectado a las {}"
   artist_scrobbles: "{} - {} Scrobbles"
   stats_loading: ">> Cargando estadísticas..."
-  stats_idle: "Estadístcas (Visible durante la reproducción)"
+  stats_idle: "Estadísticas (Visible durante la reproducción)"
   disconnected: "Desconectado"
   menu_small_image_options: "Opciones de imagen pequeña"
   menu_large_image_options: "Opciones de imagen grande"


### PR DESCRIPTION
There's the Spanish translation, proofread and everything.

Besides this, I've been working on a refactor to the way localization and config are handled (see the `localization` branch in my fork), but I'm still figuring out the best way to go about it

Namely, splitting localization into different files inside the translations folder, all following the IETF BCP 47 language tag format (so, en-US for English (United States), tr-TR for Turkish, es-ES for Spanish (Spain), and so on...), and making a small applet to set up config locally